### PR TITLE
Addition of a penalty term to consider the case of cell penetration

### DIFF
--- a/include/gCP/constitutive_laws.h
+++ b/include/gCP/constitutive_laws.h
@@ -484,6 +484,8 @@ private:
 
   double degradation_exponent;
 
+  double penalty_coefficient;
+
   double macaulay_brackets(const double value) const;
 
   double get_effective_cohesive_traction(

--- a/include/gCP/constitutive_laws.h
+++ b/include/gCP/constitutive_laws.h
@@ -414,24 +414,51 @@ private:
 template<int dim>
 class CohesiveLaw
 {
+private:
+  struct EffectiveQuantities
+  {
+    EffectiveQuantities(
+      const double                          effective_opening_displacement,
+      const dealii::Tensor<1,dim>           effective_direction,
+      const dealii::SymmetricTensor<2,dim>  effective_identity_tensor,
+      const double                          normal_opening_displacement)
+    :
+    opening_displacement(effective_opening_displacement),
+    direction(effective_direction),
+    identity_tensor(effective_identity_tensor),
+    normal_opening_displacement(normal_opening_displacement)
+    {}
+
+    const double                          opening_displacement;
+
+    const dealii::Tensor<1,dim>           direction;
+
+    const dealii::SymmetricTensor<2,dim>  identity_tensor;
+
+    double                                normal_opening_displacement;
+  };
+
 public:
   CohesiveLaw(
     const RunTimeParameters::CohesiveLawParameters parameters);
 
   dealii::Tensor<1,dim> get_cohesive_traction(
     const dealii::Tensor<1,dim> opening_displacement,
+    const dealii::Tensor<1,dim> normal_vector,
     const double                max_effective_opening_displacement,
     const double                old_effective_opening_displacement,
     const double                time_step_size) const;
 
   dealii::SymmetricTensor<2,dim> get_current_cell_gateaux_derivative(
     const dealii::Tensor<1,dim> opening_displacement,
+    const dealii::Tensor<1,dim> normal_vector,
     const double                max_effective_opening_displacement,
     const double                old_effective_opening_displacement,
     const double                time_step_size) const;
 
   dealii::SymmetricTensor<2,dim> get_neighbor_cell_gateaux_derivative(
     const dealii::Tensor<1,dim> opening_displacement,
+    const dealii::Tensor<1,dim> normal_vector,
     const double                max_effective_opening_displacement,
     const double                old_effective_opening_displacement,
     const double                time_step_size) const;
@@ -439,11 +466,16 @@ public:
   double get_degradation_function_value(const double damage_variable) const;
 
   double get_effective_opening_displacement(
-    const dealii::Tensor<1,dim> current_cell_displacement,
-    const dealii::Tensor<1,dim> neighbor_cell_displacement,
+    const dealii::Tensor<1,dim> opening_displacement,
     const dealii::Tensor<1,dim> normal_vector) const;
 
+  EffectiveQuantities
+    get_effective_quantities(
+      const dealii::Tensor<1,dim> opening_displacement,
+      const dealii::Tensor<1,dim> normal_vector) const;
+
 private:
+
   double critical_cohesive_traction;
 
   double critical_opening_displacement;
@@ -452,8 +484,15 @@ private:
 
   double degradation_exponent;
 
-  double get_master_relation(
+  double macaulay_brackets(const double value) const;
+
+  double get_effective_cohesive_traction(
     const double effective_opening_displacement) const;
+
+  dealii::Tensor<1,dim> get_cohesive_traction_direction(
+    const dealii::Tensor<1,dim> current_cell_displacement,
+    const dealii::Tensor<1,dim> neighbor_cell_displacement,
+    const dealii::Tensor<1,dim> normal_vector) const;
 };
 
 
@@ -470,7 +509,19 @@ CohesiveLaw<dim>::get_degradation_function_value(
 
 template <int dim>
 inline double
-CohesiveLaw<dim>::get_master_relation(
+CohesiveLaw<dim>::macaulay_brackets(const double value) const
+{
+  if (value > 0)
+    return value;
+  else
+    return 0.0;
+}
+
+
+
+template <int dim>
+inline double
+CohesiveLaw<dim>::get_effective_cohesive_traction(
   const double effective_opening_displacement) const
 {
   return (critical_cohesive_traction *

--- a/include/gCP/run_time_parameters.h
+++ b/include/gCP/run_time_parameters.h
@@ -394,6 +394,13 @@ struct CohesiveLawParameters
    *
    * @todo Docu
    */
+  double  penalty_coefficient;
+
+  /*!
+   * @brief
+   *
+   * @todo Docu
+   */
   bool    flag_couple_microtraction_to_damage;
 
   /*!

--- a/source/constitutive_laws.cc
+++ b/source/constitutive_laws.cc
@@ -927,14 +927,6 @@ CohesiveLaw<dim>::get_cohesive_traction(
   else
     Assert(false, dealii::ExcInternalError());
 
-  std::cout <<
-    opening_displacement.norm() << ", " <<
-    effective_quantities.normal_opening_displacement
-    << ", "<<
-    macaulay_brackets(
-      -effective_quantities.normal_opening_displacement)
-      << std::endl;
-
   cohesive_traction -=
     2.0 *
     macaulay_brackets(

--- a/source/constitutive_laws.cc
+++ b/source/constitutive_laws.cc
@@ -859,7 +859,8 @@ CohesiveLaw<dim>::CohesiveLaw(
 critical_cohesive_traction(parameters.critical_cohesive_traction),
 critical_opening_displacement(parameters.critical_opening_displacement),
 tangential_to_normal_stiffness_ratio(parameters.tangential_to_normal_stiffness_ratio),
-degradation_exponent(parameters.degradation_exponent)
+degradation_exponent(parameters.degradation_exponent),
+penalty_coefficient(parameters.penalty_coefficient)
 {}
 
 
@@ -928,7 +929,7 @@ CohesiveLaw<dim>::get_cohesive_traction(
     Assert(false, dealii::ExcInternalError());
 
   cohesive_traction -=
-    2.0 *
+    penalty_coefficient *
     macaulay_brackets(
       -effective_quantities.normal_opening_displacement) *
     critical_cohesive_traction /
@@ -1014,7 +1015,7 @@ CohesiveLaw<dim>::get_current_cell_gateaux_derivative(
 
   current_cell_gateaux_derivative -=
     -1.0 *
-    2.0 *
+    penalty_coefficient *
     macaulay_brackets(
       -effective_quantities.normal_opening_displacement /
       std::abs(effective_quantities.normal_opening_displacement)) *
@@ -1100,7 +1101,7 @@ CohesiveLaw<dim>::get_neighbor_cell_gateaux_derivative(
     Assert(false, dealii::ExcInternalError());
 
   neighbor_cell_gateaux_derivative -=
-    2.0 *
+    penalty_coefficient *
     macaulay_brackets(
       -effective_quantities.normal_opening_displacement /
       std::abs(effective_quantities.normal_opening_displacement)) *

--- a/source/constitutive_laws.cc
+++ b/source/constitutive_laws.cc
@@ -868,64 +868,85 @@ template <int dim>
 dealii::Tensor<1,dim>
 CohesiveLaw<dim>::get_cohesive_traction(
   const dealii::Tensor<1,dim> opening_displacement,
+  const dealii::Tensor<1,dim> normal_vector,
   const double                max_effective_opening_displacement,
   const double                old_effective_opening_displacement,
   const double                time_step_size) const
 {
-  AssertIsFinite(max_effective_opening_displacement);
-  AssertIsFinite(old_effective_opening_displacement);
-  AssertIsFinite(1.0 / time_step_size);
+  // Initiate cohesive traction
+  dealii::Tensor<1,dim> cohesive_traction;
 
-  const double effective_opening_displacement =
-    opening_displacement.norm();
+  // Get the effective opening displacement, the effective
+  // direction and the effective identity tensor
+  const EffectiveQuantities effective_quantities =
+    get_effective_quantities(opening_displacement, normal_vector);
 
-  AssertIsFinite(effective_opening_displacement);
-  Assert(effective_opening_displacement <=
-           max_effective_opening_displacement,
-         dealii::ExcMessage(
-           "The effective opening displacement is not suppose to be "
-           "bigger than the maximum. An update_values() call ought to "
-           "be missing in code."));
-
+  // Compute the effective opening displacement rate
   const double effective_opening_displacement_rate =
-    (effective_opening_displacement -
+    (effective_quantities.opening_displacement -
      old_effective_opening_displacement) /
     time_step_size;
 
-  dealii::Tensor<1,dim> interface_macrotraction;
+  AssertIsFinite(max_effective_opening_displacement);
+  AssertIsFinite(old_effective_opening_displacement);
+  AssertIsFinite(1.0 / time_step_size);
+  AssertIsFinite(effective_quantities.opening_displacement);
+  Assert(
+    effective_quantities.opening_displacement <=
+      max_effective_opening_displacement,
+    dealii::ExcMessage(
+      "The effective opening displacement is not suppose to be "
+      "bigger than the maximum. An update_values() call ought to "
+      "be missing in code."));
 
-  if (opening_displacement.norm() != 0.0)
-    interface_macrotraction =
-      opening_displacement / opening_displacement.norm();
-  else
-    interface_macrotraction =
-      opening_displacement;
+  // The cohesive traction has the same direction as the
+  // effective direction
+  cohesive_traction = effective_quantities.direction;
 
-  if (effective_opening_displacement ==
+  // Loading behavior
+  if (effective_quantities.opening_displacement ==
         max_effective_opening_displacement &&
       effective_opening_displacement_rate >= 0.0)
   {
-    interface_macrotraction *=
-      get_master_relation(effective_opening_displacement);
+    cohesive_traction *=
+      get_effective_cohesive_traction(
+        effective_quantities.opening_displacement);
   }
-  else if (effective_opening_displacement <
+  // Unloading and reloading behavior
+  else if (effective_quantities.opening_displacement <
              max_effective_opening_displacement ||
-           (effective_opening_displacement ==
+           (effective_quantities.opening_displacement ==
               max_effective_opening_displacement &&
             effective_opening_displacement_rate < 0.0))
   {
-    interface_macrotraction *=
-      get_master_relation(max_effective_opening_displacement) *
-      effective_opening_displacement /
+    cohesive_traction *=
+      get_effective_cohesive_traction(max_effective_opening_displacement) *
+      effective_quantities.opening_displacement /
       max_effective_opening_displacement;
   }
   else
     Assert(false, dealii::ExcInternalError());
 
-  for (unsigned int i = 0; i < dim; ++i)
-    AssertIsFinite(interface_macrotraction[i]);
+  std::cout <<
+    opening_displacement.norm() << ", " <<
+    effective_quantities.normal_opening_displacement
+    << ", "<<
+    macaulay_brackets(
+      -effective_quantities.normal_opening_displacement)
+      << std::endl;
 
-  return (interface_macrotraction);
+  cohesive_traction -=
+    2.0 *
+    macaulay_brackets(
+      -effective_quantities.normal_opening_displacement) *
+    critical_cohesive_traction /
+    critical_opening_displacement *
+    normal_vector;
+
+  for (unsigned int i = 0; i < dim; ++i)
+    AssertIsFinite(cohesive_traction[i]);
+
+  return (cohesive_traction);
 }
 
 
@@ -934,72 +955,81 @@ template <int dim>
 dealii::SymmetricTensor<2,dim>
 CohesiveLaw<dim>::get_current_cell_gateaux_derivative(
   const dealii::Tensor<1,dim> opening_displacement,
+  const dealii::Tensor<1,dim> normal_vector,
   const double                max_effective_opening_displacement,
   const double                old_effective_opening_displacement,
   const double                time_step_size) const
 {
-  AssertIsFinite(max_effective_opening_displacement);
-  AssertIsFinite(old_effective_opening_displacement);
-  AssertIsFinite(1.0 / time_step_size);
+  // Initiate Gateaux derivative
+  dealii::SymmetricTensor<2,dim> current_cell_gateaux_derivative;
 
-  const double effective_opening_displacement =
-    opening_displacement.norm();
+  // Get the effective opening displacement, the effective
+  // direction and the effective identity tensor
+  const EffectiveQuantities effective_quantities =
+    get_effective_quantities(opening_displacement, normal_vector);
 
-  AssertIsFinite(effective_opening_displacement);
-  Assert(effective_opening_displacement <=
-           max_effective_opening_displacement,
-         dealii::ExcMessage(
-           "The effective opening displacement is not suppose to be "
-           "bigger than the maximum. An update_values() call ought to "
-           "be missing in code."));
-
+  // Compute the effective opening displacement rate
   const double effective_opening_displacement_rate =
-    (effective_opening_displacement -
+    (effective_quantities.opening_displacement -
      old_effective_opening_displacement) /
     time_step_size;
 
-  dealii::SymmetricTensor<2,dim> current_cell_gateaux_derivative;
+  AssertIsFinite(max_effective_opening_displacement);
+  AssertIsFinite(old_effective_opening_displacement);
+  AssertIsFinite(1.0 / time_step_size);
+  AssertIsFinite(effective_quantities.opening_displacement);
+  Assert(
+    effective_quantities.opening_displacement <=
+      max_effective_opening_displacement,
+    dealii::ExcMessage(
+      "The effective opening displacement is not suppose to be "
+      "bigger than the maximum. An update_values() call ought to "
+      "be missing in code."));
 
-  if (effective_opening_displacement ==
+  // Loading behavior
+  if (effective_quantities.opening_displacement ==
         max_effective_opening_displacement &&
       effective_opening_displacement_rate >= 0.0)
   {
-    if (effective_opening_displacement != 0)
-      current_cell_gateaux_derivative =
-        -1.0 *
-        critical_cohesive_traction /
-        critical_opening_displacement *
-        std::exp(1.0 - effective_opening_displacement /
-                      critical_opening_displacement) *
-        (dealii::unit_symmetric_tensor<dim>() -
-        effective_opening_displacement / critical_opening_displacement *
-        dealii::symmetrize(dealii::outer_product(
-          opening_displacement / effective_opening_displacement,
-          opening_displacement / effective_opening_displacement)));
-    else
-      current_cell_gateaux_derivative =
-        -1.0 *
-        critical_cohesive_traction /
-        critical_opening_displacement *
-        std::exp(1.0 - effective_opening_displacement /
-                      critical_opening_displacement) *
-        dealii::unit_symmetric_tensor<dim>();
-
+    current_cell_gateaux_derivative =
+      -1.0 *
+      critical_cohesive_traction /
+      critical_opening_displacement *
+      std::exp(1.0 - effective_quantities.opening_displacement /
+                     critical_opening_displacement) *
+      (effective_quantities.identity_tensor -
+       effective_quantities.opening_displacement /
+         critical_opening_displacement *
+       dealii::symmetrize(dealii::outer_product(
+         effective_quantities.direction,
+         effective_quantities.direction)));
   }
-  else if (effective_opening_displacement <
+  // Unloading and reloading behavior
+  else if (effective_quantities.opening_displacement <
              max_effective_opening_displacement ||
-           (effective_opening_displacement ==
+           (effective_quantities.opening_displacement ==
               max_effective_opening_displacement &&
             effective_opening_displacement_rate < 0.0))
   {
     current_cell_gateaux_derivative =
       -1.0 *
-      get_master_relation(max_effective_opening_displacement) /
+      get_effective_cohesive_traction(max_effective_opening_displacement) /
       max_effective_opening_displacement *
-      dealii::unit_symmetric_tensor<dim>();
+      effective_quantities.identity_tensor;
   }
   else
     Assert(false, dealii::ExcInternalError());
+
+  current_cell_gateaux_derivative -=
+    -1.0 *
+    2.0 *
+    macaulay_brackets(
+      -effective_quantities.normal_opening_displacement /
+      std::abs(effective_quantities.normal_opening_displacement)) *
+    critical_cohesive_traction /
+    critical_opening_displacement *
+    dealii::symmetrize(dealii::outer_product(normal_vector,
+                                            normal_vector));
 
   for (unsigned int i = 0;
        i < current_cell_gateaux_derivative.n_independent_components; ++i)
@@ -1014,74 +1044,83 @@ template <int dim>
 dealii::SymmetricTensor<2,dim>
 CohesiveLaw<dim>::get_neighbor_cell_gateaux_derivative(
   const dealii::Tensor<1,dim> opening_displacement,
+  const dealii::Tensor<1,dim> normal_vector,
   const double                max_effective_opening_displacement,
   const double                old_effective_opening_displacement,
   const double                time_step_size) const
 {
-  AssertIsFinite(max_effective_opening_displacement);
-  AssertIsFinite(old_effective_opening_displacement);
-  AssertIsFinite(1.0 / time_step_size);
+  // Initiate Gateaux derivative
+  dealii::SymmetricTensor<2,dim> neighbor_cell_gateaux_derivative;
 
-  const double effective_opening_displacement =
-    opening_displacement.norm();
+  // Get the effective opening displacement, the effective
+  // direction and the effective identity tensor
+  const EffectiveQuantities effective_quantities =
+    get_effective_quantities(opening_displacement, normal_vector);
 
-  AssertIsFinite(effective_opening_displacement);
-  Assert(effective_opening_displacement <=
-           max_effective_opening_displacement,
-         dealii::ExcMessage(
-           "The effective opening displacement is not suppose to be "
-           "bigger than the maximum. An update_values() call ought to "
-           "be missing in code."));
-
+  // Compute the effective opening displacement rate
   const double effective_opening_displacement_rate =
-    (effective_opening_displacement -
+    (effective_quantities.opening_displacement -
      old_effective_opening_displacement) /
     time_step_size;
 
-  dealii::SymmetricTensor<2,dim> neighbor_cell_gateaux_derivative;
+  AssertIsFinite(max_effective_opening_displacement);
+  AssertIsFinite(old_effective_opening_displacement);
+  AssertIsFinite(1.0 / time_step_size);
+  AssertIsFinite(effective_quantities.opening_displacement);
+  Assert(
+    effective_quantities.opening_displacement <=
+      max_effective_opening_displacement,
+    dealii::ExcMessage(
+      "The effective opening displacement is not suppose to be "
+      "bigger than the maximum. An update_values() call ought to "
+      "be missing in code."));
 
-  if (effective_opening_displacement ==
+  // Loading behavior
+  if (effective_quantities.opening_displacement ==
         max_effective_opening_displacement &&
       effective_opening_displacement_rate >= 0.0)
   {
-    if (effective_opening_displacement != 0)
-      neighbor_cell_gateaux_derivative =
-        critical_cohesive_traction /
+    neighbor_cell_gateaux_derivative =
+      critical_cohesive_traction /
+      critical_opening_displacement *
+      std::exp(1.0 - effective_quantities.opening_displacement /
+                    critical_opening_displacement) *
+      (effective_quantities.identity_tensor -
+      effective_quantities.opening_displacement /
         critical_opening_displacement *
-        std::exp(1.0 - effective_opening_displacement /
-                      critical_opening_displacement) *
-        (dealii::unit_symmetric_tensor<dim>() -
-        effective_opening_displacement / critical_opening_displacement *
-        dealii::symmetrize(dealii::outer_product(
-          opening_displacement / effective_opening_displacement,
-          opening_displacement / effective_opening_displacement)));
-    else
-      neighbor_cell_gateaux_derivative =
-        critical_cohesive_traction /
-        critical_opening_displacement *
-        std::exp(1.0 - effective_opening_displacement /
-                      critical_opening_displacement) *
-        dealii::unit_symmetric_tensor<dim>();
-
+      dealii::symmetrize(dealii::outer_product(
+        effective_quantities.direction,
+        effective_quantities.direction)));
   }
-  else if (effective_opening_displacement <
+  // Unloading and reloading behavior
+  else if (effective_quantities.opening_displacement <
              max_effective_opening_displacement ||
-           (effective_opening_displacement ==
+           (effective_quantities.opening_displacement ==
               max_effective_opening_displacement &&
             effective_opening_displacement_rate < 0.0))
   {
     neighbor_cell_gateaux_derivative =
-      get_master_relation(max_effective_opening_displacement) /
+      get_effective_cohesive_traction(max_effective_opening_displacement) /
       max_effective_opening_displacement *
-      dealii::unit_symmetric_tensor<dim>();
+      effective_quantities.identity_tensor;
   }
   else
     Assert(false, dealii::ExcInternalError());
 
+  neighbor_cell_gateaux_derivative -=
+    2.0 *
+    macaulay_brackets(
+      -effective_quantities.normal_opening_displacement /
+      std::abs(effective_quantities.normal_opening_displacement)) *
+    critical_cohesive_traction /
+    critical_opening_displacement *
+    dealii::symmetrize(dealii::outer_product(normal_vector,
+                                             normal_vector));
+
+
   for (unsigned int i = 0;
        i < neighbor_cell_gateaux_derivative.n_independent_components; ++i)
     AssertIsFinite(neighbor_cell_gateaux_derivative.access_raw_entry(i));
-
 
   return (neighbor_cell_gateaux_derivative);
 }
@@ -1090,8 +1129,7 @@ CohesiveLaw<dim>::get_neighbor_cell_gateaux_derivative(
 
 template <int dim>
 double CohesiveLaw<dim>::get_effective_opening_displacement(
-  const dealii::Tensor<1,dim> current_cell_displacement,
-  const dealii::Tensor<1,dim> neighbor_cell_displacement,
+  const dealii::Tensor<1,dim> opening_displacement,
   const dealii::Tensor<1,dim> normal_vector) const
 {
   dealii::SymmetricTensor<2,dim> normal_projector =
@@ -1101,11 +1139,8 @@ double CohesiveLaw<dim>::get_effective_opening_displacement(
   dealii::SymmetricTensor<2,dim> tangential_projector =
     dealii::unit_symmetric_tensor<dim>() - normal_projector;
 
-  dealii::Tensor<1,dim> opening_displacement =
-    neighbor_cell_displacement - current_cell_displacement;
-
   double normal_opening_displacement =
-    (normal_projector * opening_displacement).norm();
+    macaulay_brackets(normal_vector * opening_displacement);
 
   double tangential_opening_displacement =
     (tangential_projector * opening_displacement).norm();
@@ -1117,6 +1152,63 @@ double CohesiveLaw<dim>::get_effective_opening_displacement(
                    tangential_to_normal_stiffness_ratio *
                    tangential_opening_displacement *
                    tangential_opening_displacement);
+}
+
+
+
+template <int dim>
+typename CohesiveLaw<dim>::EffectiveQuantities
+CohesiveLaw<dim>::get_effective_quantities(
+  const dealii::Tensor<1,dim> opening_displacement,
+  const dealii::Tensor<1,dim> normal_vector) const
+{
+  const double normal_opening_displacement =
+    macaulay_brackets(normal_vector * opening_displacement);
+
+  const dealii::SymmetricTensor<2,dim> normal_projector =
+    dealii::symmetrize(dealii::outer_product(normal_vector,
+                                             normal_vector));
+
+  const dealii::SymmetricTensor<2,dim> tangential_projector =
+    dealii::unit_symmetric_tensor<dim>() - normal_projector;
+
+  const dealii::Tensor<1,dim> tangential_opening_displacement =
+    tangential_projector * opening_displacement;
+
+  const double tangential_opening_displacement_norm =
+    tangential_opening_displacement.norm();
+
+  double effective_opening_displacement =
+    std::sqrt(normal_opening_displacement *
+              normal_opening_displacement
+              +
+              tangential_to_normal_stiffness_ratio *
+              tangential_to_normal_stiffness_ratio *
+              tangential_opening_displacement_norm *
+              tangential_opening_displacement_norm);
+
+  dealii::Tensor<1,dim> effective_direction =
+    (normal_opening_displacement * normal_vector +
+     tangential_to_normal_stiffness_ratio *
+     tangential_to_normal_stiffness_ratio *
+     tangential_opening_displacement);
+
+  if (effective_opening_displacement != 0.0)
+    effective_direction /= effective_opening_displacement;
+
+  const dealii::SymmetricTensor<2,dim> effective_identity_tensor =
+    macaulay_brackets(normal_opening_displacement /
+                      std::abs(normal_opening_displacement)) *
+    normal_projector
+    +
+    tangential_to_normal_stiffness_ratio *
+    tangential_to_normal_stiffness_ratio *
+    tangential_projector;
+
+  return EffectiveQuantities(effective_opening_displacement,
+                             effective_direction,
+                             effective_identity_tensor,
+                             normal_vector * opening_displacement);
 }
 
 

--- a/source/gradient_crystal_plasticity/assembly.cc
+++ b/source/gradient_crystal_plasticity/assembly.cc
@@ -1264,8 +1264,13 @@ update_local_quadrature_point_history(
                     scratch.neighbor_cell_displacement_values[face_q_point] -
                     scratch.current_cell_displacement_values[face_q_point],
                     scratch.normal_vector_values[face_q_point],
-                    local_interface_quadrature_point_history[face_q_point]->
-                      get_max_effective_opening_displacement(),
+                    std::max(
+                      cohesive_law->get_effective_opening_displacement(
+                        scratch.neighbor_cell_displacement_values[face_q_point] -
+                        scratch.current_cell_displacement_values[face_q_point],
+                        scratch.normal_vector_values[face_q_point]),
+                      local_interface_quadrature_point_history[face_q_point]->
+                        get_max_effective_opening_displacement()),
                     local_interface_quadrature_point_history[face_q_point]->
                       get_old_effective_opening_displacement(),
                     discrete_time.get_next_step_size()).norm());

--- a/source/gradient_crystal_plasticity/assembly.cc
+++ b/source/gradient_crystal_plasticity/assembly.cc
@@ -382,6 +382,7 @@ void GradientCrystalPlasticitySolver<dim>::assemble_local_jacobian(
             scratch.current_cell_gateaux_derivative_values[face_q_point] =
               cohesive_law->get_current_cell_gateaux_derivative(
                 opening_displacement,
+                scratch.normal_vector_values[face_q_point],
                 local_interface_quadrature_point_history[face_q_point]->
                   get_max_effective_opening_displacement(),
                 old_effective_opening_displacement,
@@ -390,6 +391,7 @@ void GradientCrystalPlasticitySolver<dim>::assemble_local_jacobian(
             scratch.neighbor_cell_gateaux_derivative_values[face_q_point] =
               cohesive_law->get_neighbor_cell_gateaux_derivative(
                 opening_displacement,
+                scratch.normal_vector_values[face_q_point],
                 local_interface_quadrature_point_history[face_q_point]->
                   get_max_effective_opening_displacement(),
                 old_effective_opening_displacement,
@@ -918,6 +920,7 @@ void GradientCrystalPlasticitySolver<dim>::assemble_local_residual(
             scratch.cohesive_traction_values[face_q_point] =
               cohesive_law->get_cohesive_traction(
                 opening_displacement,
+                scratch.normal_vector_values[face_q_point],
                 local_interface_quadrature_point_history[face_q_point]->
                   get_max_effective_opening_displacement(),
                 old_effective_opening_displacement,
@@ -1254,12 +1257,13 @@ update_local_quadrature_point_history(
               {
                 local_interface_quadrature_point_history[face_q_point]->update_values(
                   cohesive_law->get_effective_opening_displacement(
+                    scratch.neighbor_cell_displacement_values[face_q_point] -
                     scratch.current_cell_displacement_values[face_q_point],
-                    scratch.neighbor_cell_displacement_values[face_q_point],
                     scratch.normal_vector_values[face_q_point]),
                   cohesive_law->get_cohesive_traction(
                     scratch.neighbor_cell_displacement_values[face_q_point] -
                     scratch.current_cell_displacement_values[face_q_point],
+                    scratch.normal_vector_values[face_q_point],
                     local_interface_quadrature_point_history[face_q_point]->
                       get_max_effective_opening_displacement(),
                     local_interface_quadrature_point_history[face_q_point]->
@@ -1420,6 +1424,7 @@ store_local_effective_opening_displacement(
             cohesive_law->get_cohesive_traction(
               scratch.neighbor_cell_displacement_values[face_q_point] -
               scratch.current_cell_displacement_values[face_q_point],
+              scratch.normal_vector_values[face_q_point],
               local_interface_quadrature_point_history[face_q_point]->
                 get_max_effective_opening_displacement(),
               (scratch.neighbor_cell_old_displacement_values[face_q_point] -

--- a/source/run_time_parameters.cc
+++ b/source/run_time_parameters.cc
@@ -256,6 +256,7 @@ damage_decay_constant(0.0),
 damage_decay_exponent(1.0),
 endurance_limit(0.0),
 degradation_exponent(1.0),
+penalty_coefficient(2.0),
 flag_couple_microtraction_to_damage(true),
 flag_couple_macrotraction_to_damage(false),
 flag_set_damage_to_zero(false)
@@ -298,6 +299,10 @@ void CohesiveLawParameters::declare_parameters(
 
     prm.declare_entry("Degradation exponent",
                       "1.0",
+                      dealii::Patterns::Double());
+
+    prm.declare_entry("Penalty coefficient",
+                      "2.0",
                       dealii::Patterns::Double());
 
     prm.declare_entry("Set damage to zero",
@@ -389,6 +394,14 @@ void CohesiveLawParameters::parse_parameters(
                   degradation_exponent, 0.0));
 
     AssertIsFinite(degradation_exponent);
+
+    penalty_coefficient = prm.get_double("Penalty coefficient");
+
+    AssertThrow(penalty_coefficient > 0.0,
+                dealii::ExcLowerRangeType<double>(
+                  penalty_coefficient, 0.0));
+
+    AssertIsFinite(penalty_coefficient);
 
     flag_set_damage_to_zero = prm.get_bool("Set damage to zero");
 


### PR DESCRIPTION
`ConstitutiveLaws::CohesiveLaw<dim>` was modified using Macaulay brackets to contemplate the case of a negative opening displacement, i.e., cell penetration. If it is negative the normal component of the cohesive is replaced by a simply linear law with a high stiffness. This penalizes cell penetration but does not prevent it. 