### PR TITLE
Selection of regularization functions

### DIFF
--- a/include/gCP/constitutive_laws.h
+++ b/include/gCP/constitutive_laws.h
@@ -274,7 +274,9 @@ private:
 
   double sgn(const double value) const;
 
-  double get_regularization_factor(const double slip_rate) const;
+  double get_regularization_function_value(const double slip_rate) const;
+
+  double get_regularization_function_derivative_value(const double slip_rate) const;
 };
 
 

--- a/include/gCP/run_time_parameters.h
+++ b/include/gCP/run_time_parameters.h
@@ -38,25 +38,46 @@ enum class LoadingType
 
 
 /*!
- * @brief
+ * @brief Enum listing all the implemented regularizations of the sign
+ * function
  *
- * @todo Docu
+ * @details The approximations are controlled by the regularization
+ * paramter \f$ k \f$
  */
 enum class RegularizationFunction
 {
   /*!
-   * @brief
+   * @brief The square root approximation
    *
-   * @todo Docu
+   * @details Defined as
+   *
+   * \f[
+   *    \sgn(x) \approx \frac{x}{\sqrt{x^2 + k^2}}
+   * \f]
    */
-  PowerLaw,
+  Sqrt,
 
   /*!
-   * @brief
+   * @brief The hyperbolic tangent approximation
    *
-   * @todo Docu
+   * @details Defined as
+   *
+   * \f[
+   *    \sgn(x) \approx \tanh \left( \frac{x}{k} \right)
+   * \f]
    */
   Tanh,
+
+  /*!
+   * @brief The erf function approximation
+   *
+   * @details Defined as
+   *
+   * \f[
+   *    \sgn(x) \approx \erf  \left( \frac{\sqrt{\pi}}{k} x \right)
+   * \f]
+   */
+  Erf,
 };
 
 

--- a/source/run_time_parameters.cc
+++ b/source/run_time_parameters.cc
@@ -99,7 +99,7 @@ void ScalarMicroscopicStressLawParameters::declare_parameters(dealii::ParameterH
   {
     prm.declare_entry("Regularization function",
                       "tanh",
-                      dealii::Patterns::Selection("tanh|power-law"));
+                      dealii::Patterns::Selection("sqrt|tanh|erf"));
 
     prm.declare_entry("Regularization parameter",
                       "3e-4",

--- a/source/run_time_parameters.cc
+++ b/source/run_time_parameters.cc
@@ -129,10 +129,12 @@ void ScalarMicroscopicStressLawParameters::parse_parameters(dealii::ParameterHan
     const std::string string_regularization_function(
                       prm.get("Regularization function"));
 
-    if (string_regularization_function == std::string("tanh"))
+    if (string_regularization_function == std::string("sqrt"))
+      regularization_function = RegularizationFunction::Sqrt;
+    else if (string_regularization_function == std::string("tanh"))
       regularization_function = RegularizationFunction::Tanh;
-    else if (string_regularization_function == std::string("power-law"))
-      regularization_function = RegularizationFunction::PowerLaw;
+    else if (string_regularization_function == std::string("erf"))
+      regularization_function = RegularizationFunction::Erf;
     else
       AssertThrow(false,
                   dealii::ExcMessage("Unexpected identifier for the "


### PR DESCRIPTION
With this pull request the available regularizations of the sign function are
- $\mathrm{sgn}\left(x\right) \approx \frac{x}{\sqrt{x^2+k^2}}$
- $\mathrm{sgn}\left(x\right) \approx \tanh \left(\frac{x}{k}\right)$
- $\mathrm{sgn}\left(x\right) \approx \mathrm{erf}\left( \frac{\sqrt{\pi}}{k}x\right)$
where $k$ is the regularization parameter. Goal was to determine the influence of each regularization function in the fictitious fatigue behavior introduced by the introduced rate dependence. For the same value of $k$ the $\mathrm{erf}$ function provides the best approximation of the sign function and, as such, polluting the material response considerably less than the others. Nonetheless, it is also the most numerically challenging due to its steep tangent changes. 

![Screenshot at 2022-12-02 13-28-09](https://user-images.githubusercontent.com/50486947/205293091-e8a60938-b256-442a-9261-a223209086bc.png)



