### PR TITLE
Skip the extrapolation at load extrema

### DIFF
--- a/include/gCP/gradient_crystal_plasticity.h
+++ b/include/gCP/gradient_crystal_plasticity.h
@@ -63,6 +63,11 @@ public:
   std::shared_ptr<const ConstitutiveLaws::CohesiveLaw<dim>>
     get_cohesive_law() const;
 
+  void set_cyclic_step_data(
+    const RunTimeParameters::LoadingType  loading_type,
+    const unsigned int                    n_steps_in_loading_phase,
+    const unsigned int                    n_steps_per_half_cycle);
+
   /*!
    * @brief Returns a const reference to the @ref dof_handler
    */
@@ -151,6 +156,17 @@ private:
    * @todo Temporary member
    */
   RunTimeParameters::LoadingType                    loading_type;
+
+  struct CyclicStepData
+  {
+    RunTimeParameters::LoadingType  loading_type;
+
+    unsigned int                    n_steps_in_loading_phase;
+
+    unsigned int                    n_steps_per_half_cycle;
+  };
+
+  CyclicStepData                                    cyclic_step_data;
 
   bool                                              flag_init_was_called;
 

--- a/include/gCP/run_time_parameters.h
+++ b/include/gCP/run_time_parameters.h
@@ -605,6 +605,13 @@ struct SolverParameters
    *
    * @todo Docu
    */
+  bool                flag_skip_extrapolation_at_extrema;
+
+  /*!
+   * @brief
+   *
+   * @todo Docu
+   */
   bool                print_sparsity_pattern;
 
   /*!

--- a/input/simple_shear.prm
+++ b/input/simple_shear.prm
@@ -4,14 +4,14 @@ set Verbose = true
 
 
 subsection Input files
-  set Euler angles path name    = input/simple_shear_Lara/euler_angles_15_0
-  set Slip directions path name = input/simple_shear_Lara/slip_directions
-  set Slip normals path name    = input/simple_shear_Lara/slip_normals
+  set Euler angles path name    = input/cyclic_simple_shear/euler_angles_30_0
+  set Slip directions path name = input/cyclic_simple_shear/slip_directions
+  set Slip normals path name    = input/cyclic_simple_shear/slip_normals
 end
 
 
 subsection Output control parameters
-  set Graphical output directory = results/simple_shear_default/
+  set Graphical output directory = /calculate/results/default/
   set Graphical output frequency = 1
   set Terminal output frequency  = 1
 end
@@ -20,8 +20,8 @@ end
 subsection Simple shear
   set Height of the strip                              = 1.0
   set Number of equally sized divisions in y-direction = 2
-  set Maximum shear strain at the upper boundary       = 0.03
-  set Minimum shear strain at the upper boundary       = 0.015
+  set Maximum shear strain at the upper boundary       = 0.02
+  set Minimum shear strain at the upper boundary       = 0.01
   set Width of the strip                               = 0.1
 end
 
@@ -29,12 +29,18 @@ end
 subsection Solver parameters
   set Allow decohesion at grain boundaries    = true
   set Boundary conditions at grain boundaries = microtraction
-  set Logger output directory                 = results/simple_shear_default/
+  set Logger output directory                 = /calculate/results/default/
+  set Skip extrapolation of start value at extrema = false
   set Print sparsity pattern                  = false
   set Verbose                                 = false
 
 
   subsection Constitutive laws' parameters
+    subsection Contact law's parameters
+      set Penalty coefficient = 1e3
+      set Stiffness           = 28e3
+    end
+
     subsection Decohesion law's parameters
       set Couple macrotraction to damage       = true
       set Couple microtraction to damage       = true
@@ -63,8 +69,8 @@ subsection Solver parameters
       set Hardening parameter      = 1.4
       set Initial slip resistance  = 490
       set Linear hardening modulus = 550
-      set Regularization function  = tanh
-      set Regularization parameter = 3e-4
+      set Regularization function  = erf
+      set Regularization parameter = 10e-7
     end
 
     subsection Vector microscopic stress law's parameters
@@ -77,7 +83,7 @@ subsection Solver parameters
   subsection Nonlinear solver's parameters
     set Absolute tolerance of the Krylov-solver              = 1e-9
     set Maximum number of iterations of the Krylov-solver    = 1000
-    set Maximum number of iterations of the nonlinear solver = 500
+    set Maximum number of iterations of the nonlinear solver = 30
     set Relative tolerance of the Krylov-solver              = 1e-8
     set Tolerance of the newton update                       = 1e-15
     set Tolerance of the residual                            = 1e-8
@@ -96,15 +102,15 @@ subsection Spatial discretization parameters
 end
 
 subsection Temporal discretization parameters
-  set Number of steps in loading phase = 201
-  set Number of steps per half cycle   = 101
+  set Number of steps in loading phase = 50
+  set Number of steps per half cycle   = 25
   set End time                         = 1.0
   set Initial loading time             = 1.0
   set Loading type                     = cyclic
-  set Number of cycles                 = 2
+  set Number of cycles                 = 1
   set Period                           = 1.0
   set Start time                       = 0.0
-  set Time step size                   = 1e-1
+  set Time step size                   = 1e-3
 end
 
 

--- a/simple_shear.cc
+++ b/simple_shear.cc
@@ -454,6 +454,11 @@ string_width(
       }
     }
   }
+
+  gCP_solver.set_cyclic_step_data(
+    parameters.temporal_discretization_parameters.loading_type,
+    parameters.temporal_discretization_parameters.n_steps_in_loading_phase,
+    parameters.temporal_discretization_parameters.n_steps_per_half_cycle);
 }
 
 

--- a/source/gradient_crystal_plasticity/setup.cc
+++ b/source/gradient_crystal_plasticity/setup.cc
@@ -189,6 +189,19 @@ void GradientCrystalPlasticitySolver<dim>::set_supply_term(
 
 
 template <int dim>
+void GradientCrystalPlasticitySolver<dim>::set_cyclic_step_data(
+  const RunTimeParameters::LoadingType  loading_type,
+  const unsigned int                    n_steps_in_loading_phase,
+  const unsigned int                    n_steps_per_half_cycle)
+{
+  cyclic_step_data.loading_type             = loading_type;
+  cyclic_step_data.n_steps_in_loading_phase = n_steps_in_loading_phase;
+  cyclic_step_data.n_steps_per_half_cycle   = n_steps_per_half_cycle;
+}
+
+
+
+template <int dim>
 void GradientCrystalPlasticitySolver<dim>::
 set_neumann_boundary_condition(
   const dealii::types::boundary_id                      boundary_id,
@@ -440,6 +453,15 @@ template void gCP::GradientCrystalPlasticitySolver<2>::set_supply_term(
   std::shared_ptr<dealii::TensorFunction<1,2>>);
 template void gCP::GradientCrystalPlasticitySolver<3>::set_supply_term(
   std::shared_ptr<dealii::TensorFunction<1,3>>);
+
+template void gCP::GradientCrystalPlasticitySolver<2>::set_cyclic_step_data(
+  const RunTimeParameters::LoadingType,
+  const unsigned int,
+  const unsigned int);
+template void gCP::GradientCrystalPlasticitySolver<3>::set_cyclic_step_data(
+  const RunTimeParameters::LoadingType,
+  const unsigned int,
+  const unsigned int);
 
 template void gCP::GradientCrystalPlasticitySolver<2>::set_neumann_boundary_condition(
   const dealii::types::boundary_id,

--- a/source/run_time_parameters.cc
+++ b/source/run_time_parameters.cc
@@ -471,6 +471,7 @@ allow_decohesion(false),
 boundary_conditions_at_grain_boundaries(
   BoundaryConditionsAtGrainBoundaries::Microfree),
 logger_output_directory("results/default/"),
+flag_skip_extrapolation_at_extrema(false),
 print_sparsity_pattern(false),
 verbose(false)
 {}
@@ -531,6 +532,10 @@ void SolverParameters::declare_parameters(dealii::ParameterHandler &prm)
   prm.declare_entry("Logger output directory",
                     "results/default/",
                     dealii::Patterns::DirectoryName());
+
+  prm.declare_entry("Skip extrapolation of start value at extrema",
+                    "false",
+                    dealii::Patterns::Bool());
 
   prm.declare_entry("Print sparsity pattern",
                     "false",
@@ -621,6 +626,9 @@ void SolverParameters::parse_parameters(dealii::ParameterHandler &prm)
 
 
   logger_output_directory = prm.get("Logger output directory");
+
+  flag_skip_extrapolation_at_extrema =
+    prm.get_bool("Skip extrapolation of start value at extrema");
 
   print_sparsity_pattern = prm.get_bool("Print sparsity pattern");
 


### PR DESCRIPTION
The start value of each non-linear iteration is determined via extrapolation of old solutions. In the case of a load reversal this may lead to divergence. This pull requests enables to skip the extrapolation at the extrema if the user chooses to.