### PR TITLE
Fix method to mark cells at grain boundary

### DIFF
--- a/include/gCP/fe_field.h
+++ b/include/gCP/fe_field.h
@@ -12,6 +12,7 @@
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/generic_linear_algebra.h>
 
+#include <gCP/utilities.h>
 namespace gCP
 {
 
@@ -71,6 +72,13 @@ public:
    */
   void setup_extractors(const unsigned n_crystals,
                         const unsigned n_slips);
+
+  /*!
+   * @brief
+   *
+   * @todo Docu
+   */
+  void update_ghost_material_ids();
 
   /*!
    * @brief Set ups the degress of freedom of the vector-valued

--- a/semicoupled_rve.cc
+++ b/semicoupled_rve.cc
@@ -390,6 +390,9 @@ void SemicoupledProblem<dim>::setup()
   fe_field->setup_extractors(crystals_data->get_n_crystals(),
                              crystals_data->get_n_slips());
 
+  // Update the material ids of ghost cells
+  fe_field->update_ghost_material_ids();
+
   // Set the active finite elemente index of each cell
   for (const auto &cell :
        fe_field->get_dof_handler().active_cell_iterators())
@@ -472,8 +475,8 @@ void SemicoupledProblem<dim>::setup_constraints()
         if (cell->is_locally_owned())
           for (const auto &face_index : cell->face_indices())
             if (!cell->face(face_index)->at_boundary() &&
-                cell->active_fe_index() !=
-                  cell->neighbor(face_index)->active_fe_index())
+                cell->material_id() !=
+                  cell->neighbor(face_index)->material_id())
             {
               AssertThrow(
                 cell->neighbor(face_index)->active_fe_index() ==
@@ -482,7 +485,7 @@ void SemicoupledProblem<dim>::setup_constraints()
                   "The active finite element index and the material "
                   " identifier of the cell have to coincide!"));
 
-              const unsigned int crystal_id = cell->active_fe_index();
+              const unsigned int crystal_id = cell->material_id();
 
               cell->face(face_index)->get_dof_indices(
                 local_face_dof_indices,
@@ -521,7 +524,7 @@ void SemicoupledProblem<dim>::setup_constraints()
               != lower_corner_points.end())
           {
               // Get the crystal identifier for the current cell
-            const unsigned int crystal_id = cell->active_fe_index();
+            const unsigned int crystal_id = cell->material_id();
 
             for (unsigned int i = 0; i < dim; i++)
             {
@@ -562,8 +565,8 @@ void SemicoupledProblem<dim>::setup_constraints()
         if (cell->is_locally_owned())
           for (const auto &face_index : cell->face_indices())
             if (!cell->face(face_index)->at_boundary() &&
-                cell->active_fe_index() !=
-                  cell->neighbor(face_index)->active_fe_index())
+                cell->material_id() !=
+                  cell->neighbor(face_index)->material_id())
             {
               AssertThrow(
                 cell->neighbor(face_index)->active_fe_index() ==
@@ -572,7 +575,7 @@ void SemicoupledProblem<dim>::setup_constraints()
                   "The active finite element index and the material "
                   " identifier of the cell have to coincide!"));
 
-              const unsigned int crystal_id = cell->active_fe_index();
+              const unsigned int crystal_id = cell->material_id();
 
               cell->face(face_index)->get_dof_indices(
                 local_face_dof_indices,
@@ -611,7 +614,7 @@ void SemicoupledProblem<dim>::setup_constraints()
               != lower_corner_points.end())
           {
               // Get the crystal identifier for the current cell
-            const unsigned int crystal_id = cell->active_fe_index();
+            const unsigned int crystal_id = cell->material_id();
 
             for (unsigned int i = 0; i < dim; i++)
             {

--- a/simple_shear.cc
+++ b/simple_shear.cc
@@ -522,6 +522,9 @@ void SimpleShearProblem<dim>::setup()
   fe_field->setup_extractors(crystals_data->get_n_crystals(),
                              crystals_data->get_n_slips());
 
+  // Update the material ids of ghost cells
+  fe_field->update_ghost_material_ids();
+
   // Set the active finite elemente index of each cell
   for (const auto &cell :
        fe_field->get_dof_handler().active_cell_iterators())
@@ -656,8 +659,8 @@ void SimpleShearProblem<dim>::setup_constraints()
         if (cell->is_locally_owned())
           for (const auto &face_index : cell->face_indices())
             if (!cell->face(face_index)->at_boundary() &&
-                cell->active_fe_index() !=
-                  cell->neighbor(face_index)->active_fe_index())
+                cell->material_id() !=
+                  cell->neighbor(face_index)->material_id())
             {
               AssertThrow(
                 cell->neighbor(face_index)->active_fe_index() ==
@@ -666,7 +669,7 @@ void SimpleShearProblem<dim>::setup_constraints()
                   "The active finite element index and the material "
                   " identifier of the cell have to coincide!"));
 
-              const unsigned int crystal_id = cell->active_fe_index();
+              const unsigned int crystal_id = cell->material_id();
 
               cell->face(face_index)->get_dof_indices(
                 local_face_dof_indices,
@@ -742,8 +745,8 @@ void SimpleShearProblem<dim>::setup_constraints()
         if (cell->is_locally_owned())
           for (const auto &face_index : cell->face_indices())
             if (!cell->face(face_index)->at_boundary() &&
-                cell->active_fe_index() !=
-                  cell->neighbor(face_index)->active_fe_index())
+                cell->material_id() !=
+                  cell->neighbor(face_index)->material_id())
             {
               AssertThrow(
                 cell->neighbor(face_index)->active_fe_index() ==
@@ -752,7 +755,7 @@ void SimpleShearProblem<dim>::setup_constraints()
                   "The active finite element index and the material "
                   " identifier of the cell have to coincide!"));
 
-              const unsigned int crystal_id = cell->active_fe_index();
+              const unsigned int crystal_id = cell->material_id();
 
               cell->face(face_index)->get_dof_indices(
                 local_face_dof_indices,

--- a/source/fe_field.cc
+++ b/source/fe_field.cc
@@ -93,6 +93,14 @@ void FEField<dim>::setup_extractors(const unsigned n_crystals,
 
 
 template<int dim>
+void FEField<dim>::update_ghost_material_ids()
+{
+  Utilities::update_ghost_material_ids(dof_handler);
+}
+
+
+
+template<int dim>
 void FEField<dim>::setup_dofs()
 {
   AssertThrow(flag_setup_extractors_was_called,

--- a/source/gradient_crystal_plasticity/assembly.cc
+++ b/source/gradient_crystal_plasticity/assembly.cc
@@ -102,7 +102,7 @@ void GradientCrystalPlasticitySolver<dim>::assemble_local_jacobian(
   cell->get_dof_indices(data.local_dof_indices);
 
   // Get the crystal identifier for the current cell
-  const unsigned int crystal_id = cell->active_fe_index();
+  const unsigned int crystal_id = cell->material_id();
 
   // Get the stiffness tetrad of the current crystal
   scratch.stiffness_tetrad =
@@ -268,8 +268,8 @@ void GradientCrystalPlasticitySolver<dim>::assemble_local_jacobian(
 
     for (const auto &face_index : cell->face_indices())
       if (!cell->face(face_index)->at_boundary() &&
-          cell->active_fe_index() !=
-            cell->neighbor(face_index)->active_fe_index())
+          cell->material_id() !=
+            cell->neighbor(face_index)->material_id())
       {
         // Reset local data
         data.local_coupling_matrix = 0.0;
@@ -657,7 +657,7 @@ void GradientCrystalPlasticitySolver<dim>::assemble_local_residual(
   cell->get_dof_indices(data.local_dof_indices);
 
   // Get the crystal identifier for the current cell
-  const unsigned int crystal_id = cell->active_fe_index();
+  const unsigned int crystal_id = cell->material_id();
 
   // Update the hp::FEValues instance to the values of the current cell
   scratch.hp_fe_values.reinit(cell);
@@ -809,8 +809,8 @@ void GradientCrystalPlasticitySolver<dim>::assemble_local_residual(
         RunTimeParameters::BoundaryConditionsAtGrainBoundaries::Microtraction))
     for (const auto &face_index : cell->face_indices())
       if (!cell->face(face_index)->at_boundary() &&
-          cell->active_fe_index() !=
-            cell->neighbor(face_index)->active_fe_index())
+          cell->material_id() !=
+            cell->neighbor(face_index)->material_id())
       {
         // Get the crystal identifier for the neighbour cell
         const unsigned int neighbour_crystal_id =
@@ -1182,7 +1182,7 @@ update_local_quadrature_point_history(
   gCP::AssemblyData::QuadraturePointHistory::Copy               &)
 {
   // Get the crystal identifier for the current cell
-  const unsigned int crystal_id = cell->active_fe_index();
+  const unsigned int crystal_id = cell->material_id();
 
   // Get the local quadrature point history instance
   const std::vector<std::shared_ptr<QuadraturePointHistory<dim>>>
@@ -1237,7 +1237,7 @@ update_local_quadrature_point_history(
       {
         // Get the crystal identifier for the neighbor cell
         const unsigned int neighbor_crystal_id =
-          cell->neighbor(face_index)->active_fe_index();
+          cell->neighbor(face_index)->material_id();
 
         // Get the local quadrature point history instance
         const std::vector<std::shared_ptr<InterfaceQuadraturePointHistory<dim>>>
@@ -1435,7 +1435,7 @@ store_local_effective_opening_displacement(
   gCP::AssemblyData::QuadraturePointHistory::Copy               &)
 {
   // Get the crystal identifier for the current cell
-  const unsigned int crystal_id = cell->active_fe_index();
+  const unsigned int crystal_id = cell->material_id();
 
   // Reset local data
   scratch.reset();
@@ -1449,7 +1449,7 @@ store_local_effective_opening_displacement(
       {
         // Get the crystal identifier for the neighbor cell
         const unsigned int neighbor_crystal_id =
-          cell->neighbor(face_index)->active_fe_index();
+          cell->neighbor(face_index)->material_id();
 
         // Get the local quadrature point history instance
         const std::vector<std::shared_ptr<InterfaceQuadraturePointHistory<dim>>>

--- a/source/gradient_crystal_plasticity/setup.cc
+++ b/source/gradient_crystal_plasticity/setup.cc
@@ -50,8 +50,8 @@ void GradientCrystalPlasticitySolver<dim>::init()
     if (cell->is_locally_owned())
       for (const auto &face_index : cell->face_indices())
         if (!cell->face(face_index)->at_boundary() &&
-            cell->active_fe_index() !=
-              cell->neighbor(face_index)->active_fe_index())
+            cell->material_id() !=
+              cell->neighbor(face_index)->material_id())
         {
           cell_is_at_grain_boundary(cell->active_cell_index()) = 1.0;
           break;
@@ -294,8 +294,8 @@ void GradientCrystalPlasticitySolver<dim>::make_sparsity_pattern(
                 RunTimeParameters::BoundaryConditionsAtGrainBoundaries::Microtraction))
           for (const auto &face_index : cell->face_indices())
             if (!cell->face(face_index)->at_boundary() &&
-                cell->active_fe_index() !=
-                  cell->neighbor(face_index)->active_fe_index())
+                cell->material_id() !=
+                  cell->neighbor(face_index)->material_id())
             {
               AssertThrow(
                 cell->neighbor(face_index)->active_fe_index() ==

--- a/source/postprocessing.cc
+++ b/source/postprocessing.cc
@@ -587,7 +587,7 @@ void SimpleShear<dim>::compute_stress_12_at_boundary()
           local_stress_12 = 0.0;
 
           // Get the crystal identifier for the current cell
-          const unsigned int crystal_id = cell->active_fe_index();
+          const unsigned int crystal_id = cell->material_id();
 
           // Update the hp::FEFaceValues instance to the values of the current cell
           hp_fe_face_values.reinit(cell, face);
@@ -947,7 +947,7 @@ void Homogenization<dim>::compute_macroscopic_stress()
       cell_volume                       = 0.0;
 
       // Get the crystal identifier for the current cell
-      const unsigned int crystal_id = cell->active_fe_index();
+      const unsigned int crystal_id = cell->material_id();
 
       // Update the hp::FEFaceValues instance to the values of the current cell
       hp_fe_values.reinit(cell);


### PR DESCRIPTION
Fixes #7 

Material id are now updated at ghost cells. 
Crystals ids are obtained from the material ids.